### PR TITLE
fix: use https instead of ssh for git cloning

### DIFF
--- a/src/generators/plugin.ts
+++ b/src/generators/plugin.ts
@@ -56,7 +56,7 @@ export default class Plugin extends Generator {
     ]);
 
     const directory = path.resolve(this.answers.name);
-    exec(`git clone git@github.com:salesforcecli/plugin-template-sf.git ${directory}`);
+    exec(`git clone https://github.com/salesforcecli/plugin-template-sf.git ${directory}`);
     fs.rmSync(`${path.resolve(this.answers.name, '.git')}`, { recursive: true });
     this.destinationRoot(directory);
     this.env.cwd = this.destinationPath();


### PR DESCRIPTION
### What does this PR do?
It changes the git clone command that runs as part of the `dev generate plugin` command to use https instead of ssh to clone a repo.

This is so that users running the `dev generate plugin` command don't have to have ssh keys setup.

### What issues does this PR fix or reference?
[[skip-validate-pr]]