### PR TITLE
fix: wrap flags with hyphens with quotes

### DIFF
--- a/src/commands/dev/generate/flag.ts
+++ b/src/commands/dev/generate/flag.ts
@@ -176,6 +176,9 @@ export default class DevGenerateFlag extends SfCommand<void> {
     await this.updateMarkdownFile(answers, standardizedCommandId);
 
     exec(`yarn prettier --write ${commandFilePath}.ts`);
+
+    exec('yarn compile');
+
     this.log(`Added ${answers.name} flag to ${commandFilePath}.ts`);
   }
 
@@ -398,7 +401,9 @@ export default class DevGenerateFlag extends SfCommand<void> {
     if (answers.integerDefault && answers.multiple) flagOptions.push(`default: [${answers.integerDefault}]`);
     if (answers.type === 'enum') flagOptions.push('options: []');
 
-    const newFlag = `    ${answers.name}: Flags.${answers.type}({
+    const flagName = answers.name.includes('-') ? `'${answers.name}'` : answers.name;
+
+    const newFlag = `    ${flagName}: Flags.${answers.type}({
       ${flagOptions.join(',\n      ')},
     }),`.split('\n');
 


### PR DESCRIPTION
### What does this PR do?

- Wraps flag name in quotes if it contains a hyphen
- Compiles the project after adding the flag so that subsequent `sf dev generate flag` executions know about the generated flag

### What issues does this PR fix or reference?
[skip-validate-pr]