### PR TITLE
Better validation for plugin names

### DIFF
--- a/messages/plugin.generator.md
+++ b/messages/plugin.generator.md
@@ -14,9 +14,23 @@ Enter the name of your new plugin: (Internal plugins must start with "plugin-", 
 
 Enter the name of your new plugin:
 
-# error.InvalidName
+# error.Invalid2ppName
 
 The name must start with "plugin-" and be lowercase.
+
+# error.Invalid3ppName
+
+The name must be a valid npm package name:
+
+- Package name length should be greater than zero
+- All the characters in the package name must be lowercase i.e., no uppercase or mixed case names are allowed
+- Package name can consist of hyphens
+- Package name must not contain any non-url-safe characters (since name ends up being part of a URL)
+- Package name should not start with . or _
+- Package name should not contain any spaces
+- Package name should not contain any of the following characters: ~)('!*
+- Package name cannot be the same as a node.js/io.js core module nor a reserved/blacklisted name
+- Package name length cannot exceed 214
 
 # question.description
 

--- a/src/generators/plugin.ts
+++ b/src/generators/plugin.ts
@@ -14,7 +14,7 @@ import replace = require('replace-in-file');
 import { camelCase } from 'change-case';
 import { Messages } from '@salesforce/core';
 import { Hook, NYC, PackageJson } from '../types';
-import { addHookToPackageJson, readJson } from '../util';
+import { addHookToPackageJson, readJson, validatePluginName } from '../util';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.load('@salesforce/plugin-dev', 'plugin.generator', [
@@ -67,7 +67,7 @@ export default class Plugin extends Generator {
         name: 'name',
         message: messages.getMessage('question.internal.name'),
         validate: (input: string): boolean | string => {
-          const result = /plugin-([a-z][a-z]*)(-[a-z]+)*$/.test(input);
+          const result = validatePluginName(input, '2PP');
           if (result) return true;
 
           return messages.getMessage('error.Invalid2ppName');
@@ -79,8 +79,7 @@ export default class Plugin extends Generator {
         name: 'name',
         message: messages.getMessage('question.external.name'),
         validate: (input: string): string | boolean => {
-          // This regex for valid npm package name is taken from https://github.com/dword-design/package-name-regex/blob/master/src/index.js
-          const result = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(input);
+          const result = validatePluginName(input, '3PP');
           if (result) return true;
 
           return messages.getMessage('error.Invalid3ppName');

--- a/src/generators/plugin.ts
+++ b/src/generators/plugin.ts
@@ -26,7 +26,8 @@ const messages = Messages.load('@salesforce/plugin-dev', 'plugin.generator', [
   'question.author',
   'question.code-coverage',
   'question.hooks',
-  'error.InvalidName',
+  'error.Invalid2ppName',
+  'error.Invalid3ppName',
 ]);
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment
@@ -66,10 +67,10 @@ export default class Plugin extends Generator {
         name: 'name',
         message: messages.getMessage('question.internal.name'),
         validate: (input: string): boolean | string => {
-          const result = /plugin-[a-z]+$/.test(input);
+          const result = /plugin-([a-z][a-z]*)(-[a-z]+)*$/.test(input);
           if (result) return true;
 
-          return messages.getMessage('error.InvalidName');
+          return messages.getMessage('error.Invalid2ppName');
         },
         when: (answers: { internal: boolean }): boolean => answers.internal,
       },
@@ -77,7 +78,13 @@ export default class Plugin extends Generator {
         type: 'input',
         name: 'name',
         message: messages.getMessage('question.external.name'),
-        validate: (input: string): boolean => Boolean(input),
+        validate: (input: string): string | boolean => {
+          // This regex for valid npm package name is taken from https://github.com/dword-design/package-name-regex/blob/master/src/index.js
+          const result = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(input);
+          if (result) return true;
+
+          return messages.getMessage('error.Invalid3ppName');
+        },
         when: (answers: { internal: boolean }): boolean => !answers.internal,
       },
       {

--- a/src/util.ts
+++ b/src/util.ts
@@ -40,6 +40,13 @@ export function fileExists(file: string): boolean {
   }
 }
 
+export function validatePluginName(name: string, type: '2PP' | '3PP'): boolean {
+  // This regex for valid npm package name is taken from https://github.com/dword-design/package-name-regex/blob/master/src/index.js
+  const validNpmPackageName = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+  const valid2PPName = /plugin-([a-z][a-z]*)(-[a-z]+)*$/;
+  return type === '2PP' ? validNpmPackageName.test(name) && valid2PPName.test(name) : validNpmPackageName.test(name);
+}
+
 export class FlagBuilder {
   public constructor(private answers: FlagAnswers, private commandFilePath: string) {}
 

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -7,7 +7,7 @@
 
 import * as sinon from 'sinon';
 import { expect } from 'chai';
-import { FlagBuilder } from '../src/util';
+import { FlagBuilder, validatePluginName } from '../src/util';
 import { FlagAnswers } from '../src/types';
 
 const templateCommand = `
@@ -776,6 +776,117 @@ describe('FlagBuilder', () => {
       expect(updated).to.include(
         "const messages = Messages.load('@salesforce/plugin-rosie', 'hello.world', ['summary', 'description', 'examples', 'info.hello', 'flags.my-flag.summary']);"
       );
+    });
+  });
+});
+
+describe('validatePluginName', () => {
+  describe('2PP', () => {
+    it('should return true for valid plugin name', () => {
+      expect(validatePluginName('plugin-test', '2PP')).to.be.true;
+    });
+
+    it('should return true for valid plugin name with multiple hyphens', () => {
+      expect(validatePluginName('plugin-test-with-hyphens', '2PP')).to.be.true;
+    });
+
+    it('should return false for empty plugin name', () => {
+      expect(validatePluginName('', '2PP')).to.be.false;
+    });
+
+    it('should return false for plugin name with number', () => {
+      expect(validatePluginName('plugin-test2', '2PP')).to.be.false;
+    });
+
+    it('should return false for plugin name that does not start with plugin-', () => {
+      expect(validatePluginName('my-plugin', '2PP')).to.be.false;
+    });
+
+    it('should return false for plugin name that contains special characters', () => {
+      expect(validatePluginName('plugin-test!', '2PP')).to.be.false;
+    });
+  });
+
+  describe('3PP', () => {
+    it('should return true for valid plugin name', () => {
+      expect(validatePluginName('my-plugin', '3PP')).to.be.true;
+    });
+
+    it('should return true for valid plugin name with multiple hyphens', () => {
+      expect(validatePluginName('my-plugin-with-hyphens', '3PP')).to.be.true;
+    });
+
+    it('should return true for valid plugin name with underscores', () => {
+      expect(validatePluginName('my_plugin', '3PP')).to.be.true;
+    });
+
+    it('should return true for valid plugin name with period', () => {
+      expect(validatePluginName('my.plugin', '3PP')).to.be.true;
+    });
+
+    it('should return true for valid plugin name with numbers', () => {
+      expect(validatePluginName('my-plugin-123', '3PP')).to.be.true;
+    });
+
+    it('should return true for valid plugin name that starts with @', () => {
+      expect(validatePluginName('@me/my-plugin', '3PP')).to.be.true;
+    });
+
+    it('should return false for empty plugin name', () => {
+      expect(validatePluginName('', '3PP')).to.be.false;
+    });
+
+    it('should return false for valid plugin name that starts with period', () => {
+      expect(validatePluginName('.my-plugin', '3PP')).to.be.false;
+    });
+
+    it('should return false for valid plugin name that starts with underscore', () => {
+      expect(validatePluginName('_my-plugin', '3PP')).to.be.false;
+    });
+
+    it('should return false for valid plugin name that contains capitals', () => {
+      expect(validatePluginName('my-Plugin', '3PP')).to.be.false;
+    });
+
+    it('should return false for plugin name that contains special characters', () => {
+      const specialCharacters = [
+        ' ',
+        '!',
+        '#',
+        '$',
+        '%',
+        '^',
+        '&',
+        '*',
+        '(',
+        ')',
+        '+',
+        '=',
+        '{',
+        '}',
+        '[',
+        ']',
+        '|',
+        '\\',
+        ':',
+        ';',
+        '"',
+        "'",
+        '<',
+        '>',
+        ',',
+        '?',
+        '/',
+      ];
+
+      for (const char of specialCharacters) {
+        expect(validatePluginName(`plugin-test${char}`, '3PP'), `expect name to be invalid with ${char} at end`).to.be
+          .false;
+        expect(validatePluginName(`plugin${char}test`, '3PP'), `expect name to be invalid with ${char} at middle`).to
+          .false;
+        expect(validatePluginName(`${char}plugin-test`, '3PP'), `expect name to be invalid with ${char} at beginning`)
+          .to.be.false;
+      }
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?

- Validate that 3PP and 2PP package names are valid npm package names
- Allow 2PP to use multiple hyphens in name

### What issues does this PR fix or reference?
[skip-validate-pr]