### PR TITLE
Wr/replace multiline commands

### DIFF
--- a/src/commands/dev/convert/script.ts
+++ b/src/commands/dev/convert/script.ts
@@ -84,18 +84,23 @@ export default class ConvertScript extends SfCommand<void> {
     for (let index = 0; index < lines.length; index++) {
       let line = lines[index];
       try {
-        // if we have a multi line command, build it together
-        if (line.endsWith('\\')) {
-          while (line.endsWith('\\')) {
-            line = line.concat(lines[index + 1]);
-            lines.splice(index + 1, 1);
-          }
-          // we'll grab the next line after the last line that ends with '\', see ~L82
-          line = line.concat(`${lines[index + 1]} `);
-          lines.splice(index + 1, 1);
-        }
         // if the line looks like it's a valid sfdx command
         if (line.match(/sfdx \w+/g)?.length && line.includes(':') && !line.startsWith('#')) {
+          // if we have a multi line command, build it together
+          if (line.endsWith('\\')) {
+            while (line.endsWith('\\')) {
+              line = line.concat(lines[index + 1]);
+              lines.splice(index + 1, 1);
+            }
+            // we'll grab the next line after the last line that ends with '\', see ~L82
+            line = line.concat(`${lines[index + 1]} `);
+            if (lines[index + 2] === '') {
+              // if there's a space to the next command, the multi-line commands will miss that, so check and grab it here
+              line = line.concat(os.EOL);
+            }
+            lines.splice(index, 1);
+          }
+
           const commandId = line.split('sfdx ')[1]?.split(' ')[0];
 
           const replacement = this.findReplacement(commandId);
@@ -108,12 +113,12 @@ export default class ConvertScript extends SfCommand<void> {
           }
         }
       } catch (e) {
-        line = line.concat(` # ${messages.getMessage('errorComment')}`);
+        line = line.concat(` # ${messages.getMessage('errorComment')}${os.EOL}`);
         this.warn(messages.getMessage('errorComment'));
       } finally {
         // bare minimum replace sfdx with sf, and -u -> --target-org, -v -> --target-dev-hub
         line = line.replace('sfdx ', 'sf ').replace(' -u ', ' --target-org ').replace(' -v ', ' --target-dev-hub');
-        data.push(line.replace(/\\ /g, `\\${os.EOL}`));
+        data.push(line.replace(/\\ /g, `\\${os.EOL} `));
       }
     }
 
@@ -172,7 +177,7 @@ export default class ConvertScript extends SfCommand<void> {
 
     if (replacement) {
       // we can only replace flags for commands we know about
-      const commandWithSpaces = replacement.id.replace(/:/g, ' ');
+      const commandWithSpaces = (depTo ?? replacement.id).replace(/:/g, ' ');
       if (await this.smartConfirm(messages.getMessage('replaceCommand', [commandId, commandWithSpaces]), !prompt)) {
         line = line.replace(commandId, commandWithSpaces);
       }

--- a/src/commands/dev/convert/script.ts
+++ b/src/commands/dev/convert/script.ts
@@ -76,8 +76,23 @@ export default class ConvertScript extends SfCommand<void> {
     // sfdx force:package:install -p 04t1I0000000X0P -w 10 -u myorg
     // sfdx force:package:beta:version:list -p 04t1I0000000X0P -u myorg
 
-    for (let line of lines) {
+    // sfdx force:package:install \
+    //  -p 04t1I0000000X0P \
+    //  --wait 10 \
+    //  -u myorg
+
+    for (let index = 0; index < lines.length; index++) {
+      let line = lines[index];
       try {
+        if (line.endsWith('\\')) {
+          while (line.endsWith('\\')) {
+            line = line.concat(lines[index + 1]);
+            lines.splice(index + 1, 1);
+          }
+          // we'll grab the next line after the last line that ends with '\', see L82
+          line = line.concat(`${lines[index + 1]} `);
+          lines.splice(index + 1, 1);
+        }
         // if the line looks like it's a valid sfdx command
         if (line.match(/sfdx \w+/g)?.length && line.includes(':') && !line.startsWith('#')) {
           const commandId = line.split('sfdx ')[1]?.split(' ')[0];
@@ -97,7 +112,7 @@ export default class ConvertScript extends SfCommand<void> {
       } finally {
         // bare minimum replace sfdx with sf, and -u -> --target-org, -v -> --target-dev-hub
         line = line.replace('sfdx ', 'sf ').replace(' -u ', ' --target-org ').replace(' -v ', ' --target-dev-hub');
-        data.push(line);
+        data.push(line.replace(/\\ /g, `\\${os.EOL}`));
       }
     }
 

--- a/src/commands/dev/convert/script.ts
+++ b/src/commands/dev/convert/script.ts
@@ -84,12 +84,13 @@ export default class ConvertScript extends SfCommand<void> {
     for (let index = 0; index < lines.length; index++) {
       let line = lines[index];
       try {
+        // if we have a multi line command, build it together
         if (line.endsWith('\\')) {
           while (line.endsWith('\\')) {
             line = line.concat(lines[index + 1]);
             lines.splice(index + 1, 1);
           }
-          // we'll grab the next line after the last line that ends with '\', see L82
+          // we'll grab the next line after the last line that ends with '\', see ~L82
           line = line.concat(`${lines[index + 1]} `);
           lines.splice(index + 1, 1);
         }

--- a/test/commands/dev/convert/samples/script.sh
+++ b/test/commands/dev/convert/samples/script.sh
@@ -23,3 +23,19 @@ sfdx config:set defaultusername=user -g
 sfdx force:user:create -f config/user-def.json \
   -a myuser \
   -o myorg
+
+sfdx alias:set user=myuser
+
+sfdx force:package:beta:version:list \
+  -p 04t1I0000000X0P
+
+sfdx package version promote \
+  -p 04t1I0000000X0P \
+  --target-dev-hub1.0.0.Beta_1 \
+  --target-org myorg
+
+sf force org create \
+  --definitionfile config/project-scratch-def.json \
+  --setalias myorg \
+  --setdefaultusername \
+  --durationdays 1

--- a/test/commands/dev/convert/samples/script.sh
+++ b/test/commands/dev/convert/samples/script.sh
@@ -18,3 +18,8 @@ sfdx force:apex:test:run -u myorg -c -r=human -w 10
 
 sfdx alias:set user=myuser
 sfdx config:set defaultusername=user -g
+
+# multi line commands
+sfdx force:user:create -f config/user-def.json \
+  -a myuser \
+  -o myorg


### PR DESCRIPTION
### What does this PR do?
allows the `dev convert` command to handle mult-line commands like 
```
sfdx force:user:create -f config/user-def.json \
  -a myuser \
  -o myorg
```

and converts them 

```
sf org create user --definition-file config/user-def.json \
 --set-alias myuser \
 --target-org myorg 
```

### What issues does this PR fix or reference?
@W-14135637@