### PR TITLE
test: don't assert lack of license plugin

### DIFF
--- a/test/commands/dev/generate/plugin.test.ts
+++ b/test/commands/dev/generate/plugin.test.ts
@@ -50,11 +50,6 @@ describe('dev generate plugin', () => {
       path.join(runResult.cwd, 'my-plugin', 'src', 'commands', 'hello', 'world.ts'),
       /Copyright/g
     );
-
-    runResult.assertNoFileContent(
-      path.join(runResult.cwd, 'my-plugin', '.eslintrc.js'),
-      /eslint-config-salesforce-license/g
-    );
   });
 
   it('should generate a 2PP plugin', async () => {


### PR DESCRIPTION
### What does this PR do?
license assertions is removed because the eslint config file now disables the rule (rather than testing for absence of the plugin)

this is a side-effect from letting the eslint-typesccript config manage all of the eslint stuff

### What issues does this PR fix or reference?
https://github.com/salesforcecli/plugin-dev/actions/runs/6918962025/job/18821769427?pr=422