### PR TITLE
Update generate library command

### DIFF
--- a/src/commands/dev/generate/library.ts
+++ b/src/commands/dev/generate/library.ts
@@ -5,16 +5,16 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-
 import { Messages } from '@salesforce/core';
 import { SfCommand } from '@salesforce/sf-plugins-core';
 import { generate } from '../../../util.js';
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-dev', 'dev.generate.library');
 
 export default class GenerateLibrary extends SfCommand<void> {
   public static enableJsonFlag = false;
+  public static readonly hidden = true;
   public static readonly summary = messages.getMessage('summary');
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');

--- a/src/generators/library.ts
+++ b/src/generators/library.ts
@@ -71,7 +71,7 @@ export default class Library extends Generator {
     };
 
     const directory = path.resolve(this.answers.name);
-    shelljs.exec(`git clone git@github.com:forcedotcom/library-template.git ${directory}`);
+    shelljs.exec(`git clone -b ew/update-template git@github.com:forcedotcom/library-template.git ${directory}`);
     fs.rmSync(`${path.resolve(this.answers.name, '.git')}`, { recursive: true });
     this.destinationRoot(directory);
     this.env.cwd = this.destinationPath();
@@ -87,9 +87,17 @@ export default class Library extends Generator {
       repository: `${this.answers.org}/${this.answers.name}`,
       homepage: `https://github.com/${this.answers.org}/${this.answers.name}`,
       description: this.answers.description,
+      bugs: { url: `https://github.com/${this.answers.org}/${this.answers.name}/issues` },
     };
     const final = Object.assign({}, pjson, updated);
     this.fs.writeJSON(this.destinationPath('./package.json'), final);
+
+    // Replace the message import
+    replace.sync({
+      files: `${this.env.cwd}/src/hello.ts`,
+      from: /@salesforce\/library-template/g,
+      to: `${this.answers.scope}/${this.answers.name}`,
+    });
 
     replace.sync({
       files: `${this.env.cwd}/**/*`,

--- a/src/generators/library.ts
+++ b/src/generators/library.ts
@@ -71,7 +71,7 @@ export default class Library extends Generator {
     };
 
     const directory = path.resolve(this.answers.name);
-    shelljs.exec(`git clone -b ew/update-template git@github.com:forcedotcom/library-template.git ${directory}`);
+    shelljs.exec(`git clone git@github.com:forcedotcom/library-template.git ${directory}`);
     fs.rmSync(`${path.resolve(this.answers.name, '.git')}`, { recursive: true });
     this.destinationRoot(directory);
     this.env.cwd = this.destinationPath();


### PR DESCRIPTION
TODO: Remove branch reference

### What does this PR do?
Hides the `dev generate library` command. Intended for internal use, externals could use it with some changes.
Replaces the message import in the template https://github.com/forcedotcom/library-template/pull/8

### Testing
- Clone branch
- `yarn build`
- `cd ..`
- Run `./plugin-dev/bin/run.js dev generate library`
- Inspect the created library
  - Will be in a directory matching the `Name` you provide.
  - Run `yarn build`
  - Run `yarn test` 
    - Note, link-checker might fail since this is not Open Source yet. Running `CI=1 yarn test` will skip link-check
  - Test in node repl
```
node
# enters repl
const { Hello } = require('./lib/index.js'); 
const hello = new Hello();
hello.greet('Codey');
# Prints 'Hello, Codey'
```

### What issues does this PR fix or reference?
[@W-15235736@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-15235736)