### PR TITLE
fix: remove "hooks" from the generate help

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
             "description": "Commands to help you convert an sfdx plugin to sf."
           },
           "generate": {
-            "description": "Commands for generating sf plugins, commands, and hooks."
+            "description": "Commands for generating sf plugins, commands, and flags."
           },
           "audit": {
             "description": "Commands for auditing a plugin."


### PR DESCRIPTION
### What does this PR do?

Updates the help for "dev generate", changing "hooks" to "flags". 

### What issues does this PR fix or reference?
[skip-validate-pr]