### PR TITLE
fix: no empty summary for standard flags

### DIFF
--- a/src/commands/dev/generate/flag.ts
+++ b/src/commands/dev/generate/flag.ts
@@ -87,7 +87,9 @@ const findExistingCommands = async (topicSeparator: string): Promise<string[]> =
     .sort();
 
 const updateMarkdownFile = async (answers: FlagAnswers, commandName: string): Promise<void> =>
-  fs.appendFile(
-    path.join('messages', `${commandName.split(':').join('.')}.md`),
-    `${os.EOL}# flags.${answers.name}.summary${os.EOL}${os.EOL}${answers.summary}${os.EOL}`
-  );
+  answers.summary
+    ? fs.appendFile(
+        path.join('messages', `${commandName.split(':').join('.')}.md`),
+        `${os.EOL}# flags.${answers.name}.summary${os.EOL}${os.EOL}${answers.summary}${os.EOL}`
+      )
+    : undefined;


### PR DESCRIPTION
### What does this PR do?
a real bug caught by https://github.com/forcedotcom/eslint-config-salesforce-typescript/pull/246

if you chose one of the "standard" flags then the command would write an empty summary to your messages file

### What issues does this PR fix or reference?
@W-16115298@