### PR TITLE
Use 1.0.0 on plugins and libs

### DIFF
--- a/src/commands/dev/generate/library.ts
+++ b/src/commands/dev/generate/library.ts
@@ -80,6 +80,7 @@ export default class GenerateLibrary extends SfCommand<void> {
     await generator.loadPjson();
 
     generator.pjson.name = `${answers.scope}/${answers.name}`;
+    generator.pjson.version = '1.0.0';
     generator.pjson.description = answers.description;
     generator.pjson.repository = `${answers.org}/${answers.name}`;
     generator.pjson.homepage = `https://github.com/${answers.org}/${answers.name}`;

--- a/src/commands/dev/generate/plugin.ts
+++ b/src/commands/dev/generate/plugin.ts
@@ -140,12 +140,13 @@ export default class GeneratePlugin extends SfCommand<void> {
           name: `@salesforce/${answers.name}`,
           repository: `salesforcecli/${answers.name}`,
           homepage: `https://github.com/salesforcecli/${answers.name}`,
-          description: answers.description,
         }
       : {
           name: answers.name,
-          description: answers.description,
         };
+
+    updated.version = '1.0.0';
+    updated.description = answers.description;
 
     if (answers.author) {
       updated.author = answers.author;

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export type NYC = {
 
 export type PackageJson = {
   name: string;
+  version: string;
   devDependencies: Record<string, string>;
   dependencies: Record<string, string>;
   files: string[];

--- a/test/commands/dev/generate/plugin.nut.ts
+++ b/test/commands/dev/generate/plugin.nut.ts
@@ -40,6 +40,7 @@ describe('dev generate plugin NUTs', () => {
     const packageJson = readJson<PackageJson>(packageJsonPath);
 
     expect(packageJson.name).to.equal('@salesforce/plugin-awesome');
+    expect(packageJson.version).to.equal('1.0.0');
     expect(packageJson.author).to.equal('Salesforce');
     expect(packageJson.description).to.equal('a description');
     expect(packageJson.bugs).to.equal('https://github.com/forcedotcom/cli/issues');
@@ -85,6 +86,7 @@ describe('dev generate plugin NUTs', () => {
     const packageJson = readJson<PackageJson>(packageJsonPath);
 
     expect(packageJson.name).to.equal('my-plugin');
+    expect(packageJson.version).to.equal('1.0.0');
     expect(packageJson.author).to.equal('me');
     expect(packageJson.description).to.equal('a description');
 
@@ -140,6 +142,7 @@ describe('dev generate plugin NUTs', () => {
     const packageJson = readJson<PackageJson>(packageJsonPath);
 
     expect(packageJson.name).to.equal('my-plugin');
+    expect(packageJson.version).to.equal('1.0.0');
     expect(packageJson.author).to.equal('me');
     expect(packageJson.description).to.equal('a description');
     const nycConfig = readJson<NYC>(path.join(session.dir, 'my-plugin', '.nycrc'));


### PR DESCRIPTION
### What does this PR do?
The plugin and library generators would start with the [semver version in the templates](https://github.com/salesforcecli/plugin-template-sf/blob/main/package.json#L4). This resets it to `1.0.0`.


### What issues does this PR fix or reference?
[skip-validate-pr]