### PR TITLE
W-21198400 fix: support command/index.ts layout and correct message file in flag generator

### DIFF
--- a/src/commands/dev/generate/flag.ts
+++ b/src/commands/dev/generate/flag.ts
@@ -15,7 +15,7 @@ import { Messages } from '@salesforce/core';
 import { toStandardizedId } from '@oclif/core';
 import fg from 'fast-glob';
 import { askQuestions } from '../../../prompts/series/flagPrompts.js';
-import { fileExists, build, apply } from '../../../util.js';
+import { fileExists, build, apply, resolveCommandFilePath } from '../../../util.js';
 import { FlagAnswers } from '../../../types.js';
 import { stringToChoice } from '../../../prompts/functions.js';
 
@@ -50,7 +50,7 @@ export default class DevGenerateFlag extends SfCommand<void> {
 
     const answers = await askQuestions(standardizedCommandId);
 
-    const commandFilePath = `${path.join('.', 'src', 'commands', ...standardizedCommandId.split(':'))}.ts`;
+    const commandFilePath = resolveCommandFilePath(standardizedCommandId);
 
     const newFlag = build(answers);
 
@@ -64,7 +64,7 @@ export default class DevGenerateFlag extends SfCommand<void> {
 
     await fs.writeFile(commandFilePath, updatedFile);
 
-    await updateMarkdownFile(answers, standardizedCommandId);
+    await updateMarkdownFile(answers, existing, standardizedCommandId);
 
     shelljs.exec(`yarn prettier --write ${commandFilePath}`);
 
@@ -86,10 +86,27 @@ const findExistingCommands = async (topicSeparator: string): Promise<string[]> =
     })
     .sort();
 
-const updateMarkdownFile = async (answers: FlagAnswers, commandName: string): Promise<void> =>
-  answers.summary
-    ? fs.appendFile(
-        path.join('messages', `${commandName.split(':').join('.')}.md`),
-        `${os.EOL}# flags.${answers.name}.summary${os.EOL}${os.EOL}${answers.summary}${os.EOL}`
-      )
-    : undefined;
+/**
+ * Extracts the message bundle name from Messages.loadMessages(pluginName, 'bundleName').
+ * Needed because commands may use short names (e.g. 'flexipage') or full paths ('template.generate.flexipage');
+ * inferring from the command path alone can write to the wrong file.
+ * Works for string literals only; falls back to standardizedCommandId when no match.
+ */
+const getMessageBundleFromCommand = (commandContent: string): string | undefined => {
+  const match = commandContent.match(/Messages\.loadMessages\s*\(\s*[^,]+,\s*['"]([^'"]+)['"]\s*\)/);
+  return match?.[1];
+};
+
+/** Appends the flag summary to the command's messages file. Uses bundle from command, else command path. */
+const updateMarkdownFile = async (
+  answers: FlagAnswers,
+  commandContent: string,
+  standardizedCommandId: string
+): Promise<void> => {
+  if (!answers.summary) return;
+  const messageBundle = getMessageBundleFromCommand(commandContent) ?? standardizedCommandId.split(':').join('.');
+  await fs.appendFile(
+    path.join('messages', `${messageBundle}.md`),
+    `${os.EOL}# flags.${answers.name}.summary${os.EOL}${os.EOL}${answers.summary}${os.EOL}`
+  );
+};

--- a/src/prompts/durationPrompts.ts
+++ b/src/prompts/durationPrompts.ts
@@ -18,9 +18,9 @@ export const durationPrompts = async (): Promise<
   Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
   const messages = Messages.loadMessages('@salesforce/plugin-dev', 'dev.generate.flag');
 
-  const durationUnits = (Object.values(Duration.Unit).filter((unit) => typeof unit === 'string')).map(
-    (unit) => unit.toLowerCase()
-  );
+  const durationUnits = Object.values(Duration.Unit)
+    .filter((unit) => typeof unit === 'string')
+    .map((unit) => unit.toLowerCase());
 
   const durationUnit = (await select({
     message: messages.getMessage('question.Duration.Unit'),

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,7 +6,21 @@
  */
 import fs from 'node:fs';
 import os from 'node:os';
+import path from 'node:path';
 import { FlagAnswers } from './types.js';
+
+export const resolveCommandFilePath = (standardizedCommandId: string, baseDir = '.'): string => {
+  const basePath = path.join(baseDir, 'src', 'commands', ...standardizedCommandId.split(':'));
+  const indexPath = path.join(basePath, 'index.ts');
+  const singleFilePath = `${basePath}.ts`;
+  if (fs.existsSync(indexPath)) {
+    return indexPath;
+  }
+  if (fs.existsSync(singleFilePath)) {
+    return singleFilePath;
+  }
+  return singleFilePath;
+};
 
 export function readJson<T>(filePath: string): T {
   const pjsonRaw = fs.readFileSync(filePath, 'utf-8');

--- a/test/commands/dev/generate/flag.nut.ts
+++ b/test/commands/dev/generate/flag.nut.ts
@@ -6,7 +6,8 @@
  */
 
 import path from 'node:path';
-import { TestSession, execInteractiveCmd, Interaction } from '@salesforce/cli-plugins-testkit';
+import fs from 'node:fs/promises';
+import { TestSession, execInteractiveCmd, execCmd, Interaction } from '@salesforce/cli-plugins-testkit';
 import shelljs from 'shelljs';
 import { expect } from 'chai';
 import stripAnsi from 'strip-ansi';
@@ -77,5 +78,41 @@ function getLocalBin(...parts: string[]): string {
     const localBin = getLocalBin(session.dir, 'plugin-awesome');
     const helpOutput = shelljs.exec(`${localBin} hello world --help`, { silent: false });
     expect(stripAnsi(helpOutput.stdout)).to.contain('-i, --my-integer-flag=<value>...');
+  });
+
+  it('should generate a flag for command with index.ts layout', async () => {
+    const pluginDir = path.join(session.dir, 'plugin-awesome');
+
+    execCmd('dev generate command --name template:generate:flexipage --force --nuts --unit', {
+      cwd: pluginDir,
+      ensureExitCode: 0,
+      silent: true,
+    });
+
+    const singleFilePath = path.join(pluginDir, 'src', 'commands', 'template', 'generate', 'flexipage.ts');
+    const indexDir = path.join(pluginDir, 'src', 'commands', 'template', 'generate', 'flexipage');
+    await fs.mkdir(indexDir, { recursive: true });
+    await fs.rename(singleFilePath, path.join(indexDir, 'index.ts'));
+
+    await execInteractiveCmd(
+      'dev generate flag',
+      {
+        'Select the command': ['template generate flexipage', Interaction.ENTER],
+        'Select the type': ['boolean', Interaction.ENTER],
+        "flag's name": ['index-layout-flag', Interaction.ENTER],
+        'short description': Interaction.ENTER,
+        'single-character short name': ['x', Interaction.ENTER],
+        'flag required': Interaction.No,
+      },
+      { cwd: pluginDir, ensureExitCode: 0 }
+    );
+
+    const indexPath = path.join(indexDir, 'index.ts');
+    const contents = await fs.readFile(indexPath, 'utf-8');
+    expect(contents).to.contain("'index-layout-flag': Flags.boolean(");
+
+    const localBin = getLocalBin(session.dir, 'plugin-awesome');
+    const helpOutput = shelljs.exec(`${localBin} template generate flexipage --help`, { silent: false });
+    expect(helpOutput.stdout).to.contain('-x, --index-layout-flag');
   });
 });

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -6,8 +6,11 @@
  */
 
 import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 import { expect, config as chaiConfig } from 'chai';
-import { build, apply, validatePluginName } from '../src/util.js';
+import { build, apply, validatePluginName, resolveCommandFilePath } from '../src/util.js';
 import { FlagAnswers } from '../src/types.js';
 
 chaiConfig.truncateThreshold = 0;
@@ -849,5 +852,58 @@ describe('validatePluginName', () => {
           .to.be.false;
       }
     });
+  });
+});
+
+describe('resolveCommandFilePath', () => {
+  const testDir = path.join(path.dirname(fileURLToPath(import.meta.url)), 'tmpResolveCommandFilePath');
+  const commandsDir = path.join(testDir, 'src', 'commands');
+
+  before(async () => {
+    await fs.mkdir(commandsDir, { recursive: true });
+  });
+
+  after(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('should return index.ts path when command uses directory layout', async () => {
+    const flexipageDir = path.join(commandsDir, 'template', 'generate', 'flexipage');
+    await fs.mkdir(flexipageDir, { recursive: true });
+    await fs.writeFile(path.join(flexipageDir, 'index.ts'), 'export default class Flexipage {}');
+
+    const result = resolveCommandFilePath('template:generate:flexipage', testDir);
+    expect(result).to.equal(path.join(testDir, 'src', 'commands', 'template', 'generate', 'flexipage', 'index.ts'));
+
+    await fs.rm(path.join(commandsDir, 'template'), { recursive: true, force: true });
+  });
+
+  it('should return single file path when command uses single-file layout', async () => {
+    const flexipageFile = path.join(commandsDir, 'template', 'generate', 'flexipage.ts');
+    await fs.mkdir(path.dirname(flexipageFile), { recursive: true });
+    await fs.writeFile(flexipageFile, 'export default class Flexipage {}');
+
+    const result = resolveCommandFilePath('template:generate:flexipage', testDir);
+    expect(result).to.equal(path.join(testDir, 'src', 'commands', 'template', 'generate', 'flexipage.ts'));
+
+    await fs.rm(path.join(commandsDir, 'template'), { recursive: true, force: true });
+  });
+
+  it('should prefer index.ts over single file when both exist', async () => {
+    const flexipageDir = path.join(commandsDir, 'foo', 'bar');
+    const flexipageFile = path.join(commandsDir, 'foo', 'bar.ts');
+    await fs.mkdir(flexipageDir, { recursive: true });
+    await fs.writeFile(path.join(flexipageDir, 'index.ts'), 'export default class Bar {}');
+    await fs.writeFile(flexipageFile, 'export default class Bar {}');
+
+    const result = resolveCommandFilePath('foo:bar', testDir);
+    expect(result).to.equal(path.join(testDir, 'src', 'commands', 'foo', 'bar', 'index.ts'));
+
+    await fs.rm(path.join(commandsDir, 'foo'), { recursive: true, force: true });
+  });
+
+  it('should return single file path when neither exists (fallback)', () => {
+    const result = resolveCommandFilePath('nonexistent:command', testDir);
+    expect(result).to.equal(path.join(testDir, 'src', 'commands', 'nonexistent', 'command.ts'));
   });
 });


### PR DESCRIPTION
@W-21198400@

### What does this PR do?
- Related [PR on plugin-templates](https://github.com/salesforcecli/plugin-templates/pull/853/changes#r2865055195)
- **Support `command/index.ts` layout:** The flag generator no longer assumes commands live in single files (`command.ts`). It now checks both `{path}/index.ts` and `{path}.ts`, so commands in `src/commands/template/generate/flexipage/index.ts` work correctly.
- **Correct message file resolution:** Flag summaries are written to the same messages file the command uses. The generator reads the bundle name from `Messages.loadMessages(pluginName, 'bundleName')` instead of inferring it from the command path, so commands that use short bundle names (e.g. `flexipage`) get updates in `messages/flexipage.md` instead of `messages/template.generate.flexipage.md`.
- **Refactor:** `resolveCommandFilePath` is moved to `src/util.ts` for reuse.
- **Tests:** Adds unit tests for `resolveCommandFilePath` and a NUT for the index.ts layout.

### What issues does this PR fix or reference?

- Fixes `ENOENT: no such file or directory` when running `sf dev generate flag` on commands that use the `command/index.ts` layout (e.g. `template:generate:flexipage`).
- Fixes flag summaries being written to the wrong messages file when the command's message bundle name differs from the command path.
